### PR TITLE
DOC: Fix README markdown links syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ with your particular flip-angles and TRs.
 Each product has some basic usage instructions that will be printed with either
 the -h or --help options, e.g. `qimcdespot -h`. The majority of programs take
 the input filenames as arguments on the command-line, and in addition will read
-an input text file from `stdin`. For further details, see the (documentation)[https://spinicist.github.io/QUIT], which is also available in the `Docs` folder.
+an input text file from `stdin`. For further details, see the [documentation](https://spinicist.github.io/QUIT), which is also available in the `Docs` folder.
 
 ## Getting Help
 
-If you can't find an answer to a problem in the documentation or help strings, you can open an (issue)[https://github.com/spinicist/QUIT/issues], post a question on (Neurostars)[https://neurostars.org] or find the main developer on Twitter (@spinicist).
+If you can't find an answer to a problem in the documentation or help strings, you can open an [issue](https://github.com/spinicist/QUIT/issues), post a question on [Neurostars](https://neurostars.org) or find the main developer on Twitter ([@spinicist](https://twitter.com/spinicist)).


### PR DESCRIPTION
Just noticed that you had your square and rounded brackets switched up in some of your README links, so I prettied-up your README by fixing these.

I also added a link to your Twitter, since you only gave your handle and that wasn't clickable.