### PR TITLE
Mask datatype

### DIFF
--- a/Python/qipype/sims.py
+++ b/Python/qipype/sims.py
@@ -61,7 +61,7 @@ def make_phantom(parameters, subsamp=1, mask=None, B1=True, f0=False):
     if mask:
         mask_data = np.choose(
             class_data[::subsamp, ::subsamp, ::subsamp], np.array(mask))
-        img = nib.nifti1.Nifti1Image(mask_data, affine=classes.affine)
+        img = nib.nifti1.Nifti1Image(mask_data, affine=classes.affine, dtype=np.int16)
         nib.save(img, 'mask.nii.gz')
         print('Wrote mask.nii.gz')
 


### PR DESCRIPTION
Nibabel complains about datatype if mask is saved as int64. Will throw error in Nibabel 5.0 in the future.