### PR TITLE
Compute R1 and PD without small flip angle approximation in mtsat

### DIFF
--- a/Docs/MT.rst
+++ b/Docs/MT.rst
@@ -249,7 +249,7 @@ If you use a custom contrasts file then the outputs will have the names specifie
 qi mtsat
 -----------
 
-Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and the semi-quantitative MT-Saturation parameter "delta". This is the fractional reduction in the longitudinal magnetization during one TR, expressed as a percentage. Arguably could be included in the :doc:`Relaxometry` module instead. Outputs R1 instead of T1 as this is more common in the MTSat / MPM literature. If using multi-echo input data the input should be passed through `qi mpm_r2s` first and the output ``S0`` files used as input to `qi mtsat`. Incorporate the removal of the small flip angle approximation for PDw and T1w images, as suggested in Edwards et al., 2021.
+Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and the semi-quantitative MT-Saturation parameter "delta". This is the fractional reduction in the longitudinal magnetization during one TR, expressed as a percentage. Arguably could be included in the :doc:`Relaxometry` module instead. Outputs R1 instead of T1 as this is more common in the MTSat / MPM literature. If using multi-echo input data the input should be passed through `qi mpm_r2s` first and the output ``S0`` files used as input to `qi mtsat`. By default, does not use the original small flip angle approximation to compute R1 and PD because of the results presented in Edwards et al., 2021. To still use the small flip angle approximation (e.g., for backward compatibility), use the --smallangle (-s) flag.
 
 **Example Command Line**
 
@@ -277,6 +277,12 @@ Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and t
 - ``MTSat_R1.nii.gz`` - Apparent longitudinal relaxation rate
 - ``MTSat_S0.nii.gz`` - Apparent proton density / equilibrium magnetization
 - ``MTSat_delta.nii.gz`` - MT-Sat parameter, see above.
+
+*Important Options*
+
+* ``--smallangle, -s``
+
+    If this flag is specified, use the small flip angle approximation from the original Helms et al paper. Else, do not use the approximation, as suggested in Edwards et al (default).
 
 **References**
 

--- a/Docs/MT.rst
+++ b/Docs/MT.rst
@@ -249,7 +249,7 @@ If you use a custom contrasts file then the outputs will have the names specifie
 qi mtsat
 -----------
 
-Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and the semi-quantitative MT-Saturation parameter "delta". This is the fractional reduction in the longitudinal magnetization during one TR, expressed as a percentage. Arguably could be included in the :doc:`Relaxometry` module instead. Outputs R1 instead of T1 as this is more common in the MTSat / MPM literature. If using multi-echo input data the input should be passed through `qi mpm_r2s` first and the output ``S0`` files used as input to `qi mtsat`.
+Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and the semi-quantitative MT-Saturation parameter "delta". This is the fractional reduction in the longitudinal magnetization during one TR, expressed as a percentage. Arguably could be included in the :doc:`Relaxometry` module instead. Outputs R1 instead of T1 as this is more common in the MTSat / MPM literature. If using multi-echo input data the input should be passed through `qi mpm_r2s` first and the output ``S0`` files used as input to `qi mtsat`. Incorporate the removal of the small flip angle approximation for PDw and T1w images, as suggested in Edwards et al., 2021.
 
 **Example Command Line**
 
@@ -282,6 +282,7 @@ Implementation of Gunther Helm's MT-Sat method. Calculates R1, apparent PD and t
 
 - `Helms et al <http://doi.wiley.com/10.1002/mrm.21732>`_
 - `Erratum <http://doi.wiley.com/10.1002/mrm.22607>`_
+- `Edwards et al <http://doi.org/10.1007/s10334-021-00947-8>`
 
 qi ssfp_emt
 -----------

--- a/Source/MT/MTSatModel.cpp
+++ b/Source/MT/MTSatModel.cpp
@@ -8,15 +8,22 @@ auto MTSatModel::fit(QI_ARRAYN(DataType, NI) const &     in,
     auto const  S_mt = in[2];
     auto        B1   = fixed[0];
     auto const &s    = sequence;
-
+    
+    auto al_t1_b1corr = B1 * s.al_t1;
+    auto al_pd_b1corr = B1 * s.al_pd;
+    if (!smallangle) {
+        al_t1_b1corr = 2 * tan(al_t1_b1corr / 2);
+        al_pd_b1corr = 2 * tan(al_pd_b1corr / 2);
+    }
+    
     auto const R1 =
-        std::clamp(2 * (S_t1 * tan(B1 * s.al_t1 / 2) / s.TR_t1 - S_pd * tan(B1 * s.al_pd / 2) / s.TR_pd) /
-                       (S_pd / tan(B1 * s.al_pd / 2) - S_t1 / tan(B1 * s.al_t1 / 2)),
+        std::clamp(0.5 * (S_t1 * al_t1_b1corr / s.TR_t1 - S_pd * al_pd_b1corr / s.TR_pd) /
+                       (S_pd / al_pd_b1corr - S_t1 / al_t1_b1corr),
                    0.,
                    10.);
     auto const A =
-        std::max(0.5 * S_pd * S_t1 * (s.TR_pd * tan(B1 * s.al_t1 / 2) / tan(B1 * s.al_pd / 2) - s.TR_t1 * tan(B1 * s.al_pd / 2) / tan(B1 * s.al_t1 / 2)) /
-                     (S_t1 * s.TR_pd * tan(B1 * s.al_t1 / 2) - S_pd * s.TR_t1 * tan(B1 * s.al_pd / 2)),
+        std::max((S_pd * S_t1) * (s.TR_pd * al_t1_b1corr / al_pd_b1corr - s.TR_t1 * al_pd_b1corr / al_t1_b1corr) /
+                     (S_t1 * s.TR_pd * al_t1_b1corr - S_pd * s.TR_t1 * al_pd_b1corr),
                  0.);
     auto const d           = (A * s.al_mt / S_mt - 1.0) * R1 * s.TR_mt - s.al_mt * s.al_mt / 2;
     auto const d_corrected = std::clamp(d * (1.0 - C) / (1.0 - C * B1), 0., 0.1);

--- a/Source/MT/MTSatModel.cpp
+++ b/Source/MT/MTSatModel.cpp
@@ -10,13 +10,13 @@ auto MTSatModel::fit(QI_ARRAYN(DataType, NI) const &     in,
     auto const &s    = sequence;
 
     auto const R1 =
-        std::clamp((B1 * B1 / 2.) * (S_t1 * s.al_t1 / s.TR_t1 - S_pd * s.al_pd / s.TR_pd) /
-                       (S_pd / s.al_pd - S_t1 / s.al_t1),
+        std::clamp(2 * (S_t1 * tan(B1 * s.al_t1 / 2) / s.TR_t1 - S_pd * tan(B1 * s.al_pd / 2) / s.TR_pd) /
+                       (S_pd / tan(B1 * s.al_pd / 2) - S_t1 / tan(B1 * s.al_t1 / 2)),
                    0.,
                    10.);
     auto const A =
-        std::max((S_pd * S_t1 / B1) * (s.TR_pd * s.al_t1 / s.al_pd - s.TR_t1 * s.al_pd / s.al_t1) /
-                     (S_t1 * s.TR_pd * s.al_t1 - S_pd * s.TR_t1 * s.al_pd),
+        std::max(0.5 * S_pd * S_t1 * (s.TR_pd * tan(B1 * s.al_t1 / 2) / tan(B1 * s.al_pd / 2) - s.TR_t1 * tan(B1 * s.al_pd / 2) / tan(B1 * s.al_t1 / 2)) /
+                     (S_t1 * s.TR_pd * tan(B1 * s.al_t1 / 2) - S_pd * s.TR_t1 * tan(B1 * s.al_pd / 2)),
                  0.);
     auto const d           = (A * s.al_mt / S_mt - 1.0) * R1 * s.TR_mt - s.al_mt * s.al_mt / 2;
     auto const d_corrected = std::clamp(d * (1.0 - C) / (1.0 - C * B1), 0., 0.1);

--- a/Source/MT/MTSatModel.h
+++ b/Source/MT/MTSatModel.h
@@ -7,6 +7,7 @@ using namespace std::literals;
 struct MTSatModel : QI::Model<double, double, 3, 1, 3, 0> {
     QI::MTSatSequence const &sequence;
     double const             C;
+    bool const               smallangle;
 
     std::array<const std::string, NV> const varying_names{{"PD"s, "R1"s, "delta"s}};
     std::array<const std::string, 3> const  derived_names{};

--- a/Source/MT/qi_mtsat.cpp
+++ b/Source/MT/qi_mtsat.cpp
@@ -29,13 +29,14 @@ int mtsat_main(args::Subparser &parser) {
     args::ValueFlag<std::string> b1_path(parser, "B1", "Path to B1 map", {'b', "B1"});
     args::ValueFlag<double>      C(
         parser, "C", "Correction factor for delta (default 0.4)", {'C', "C"}, 0.4);
+    args::Flag smallangle(parser, "smallangle", "Use small flip angle approx for R1 and PD calculation", {'s', "smallangle"});
     parser.Parse();
-
+    
     QI::Log(verbose, "Reading sequence parameters");
     json              input = json_file ? QI::ReadJSON(json_file.Get()) : QI::ReadJSON(std::cin);
     QI::MTSatSequence seq(input["MTSat"]);
 
-    MTSatModel model{{}, seq, C.Get()};
+    MTSatModel model{{}, seq, C.Get(), smallangle};
     if (simulate) {
         QI::SimulateModel<MTSatModel, true>(
             input,


### PR DESCRIPTION
In mtsat, compute R1 and PD (and incidentally, MTsat) without the small flip angle approximation. This follows from the suggestion in [Edwards et al., 2021](https://lup.lub.lu.se/search/publication/028387e6-909e-416a-97d4-85b95676e895). It is equivalent to setting hmri_def.small_angle_approx = false [in the hMRI-toolbox](https://github.com/hMRI-group/hMRI-toolbox/blob/035b484889e212e16afeac686998d55f91a43152/config/hmri_defaults.m#L162) (reflected in the [PD](https://github.com/hMRI-group/hMRI-toolbox/blob/035b484889e212e16afeac686998d55f91a43152/hmri_calc_A.m#L41) and [R1](https://github.com/hMRI-group/hMRI-toolbox/blob/035b484889e212e16afeac686998d55f91a43152/hmri_calc_R1.m#L41) computations).

Fix #40.